### PR TITLE
debian/control: raise Replaces: version on flatpak

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -59,7 +59,7 @@ Recommends:
  patch,
  unzip,
 Replaces:
- flatpak (<< 0.9.8-1~),
+ flatpak (<< 0.9.9~),
 Description: Flatpak application building helper
  Flatpak installs, manages and runs sandboxed desktop application bundles.
  See the flatpak package for a more comprehensive description.


### PR DESCRIPTION
Endless 0.9.8+dev18.616951a-3beos3.3.2 is higher than upstream Replaces: version of 0.9.8-1~