### PR TITLE
T21415: cherry-pick flatpak-npm-generator pre-requisites

### DIFF
--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -530,8 +530,24 @@
                         <listitem><para>The URL of a remote archive that will be downloaded. This overrides path if both are specified.</para></listitem>
                     </varlistentry>
                     <varlistentry>
+                        <term><option>md5</option> (string)</term>
+                        <listitem><para>The md5 checksum of the file, verified after download</para>
+                        <para>Note that md5 is no longer considered a safe checksum, we recommend you use at least sha256.</para>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry>
+                        <term><option>sha1</option> (string)</term>
+                        <listitem><para>The sha1 checksum of the file, verified after download</para>
+                        <para>Note that sha1 is no longer considered a safe checksum, we recommend you use at least sha256.</para>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry>
                         <term><option>sha256</option> (string)</term>
                         <listitem><para>The sha256 checksum of the file, verified after download</para></listitem>
+                    </varlistentry>
+                    <varlistentry>
+                        <term><option>sha512</option> (string)</term>
+                        <listitem><para>The sha512 checksum of the file, verified after download</para></listitem>
                     </varlistentry>
                     <varlistentry>
                         <term><option>strip-components</option> (integer)</term>
@@ -610,8 +626,24 @@
                         <listitem><para>The URL of a remote file that will be downloaded and copied into the source dir. This overrides path if both are specified.</para></listitem>
                     </varlistentry>
                     <varlistentry>
+                        <term><option>md5</option> (string)</term>
+                        <listitem><para>The md5 checksum of the file, verified after download. This is optional for local files.</para>
+                        <para>Note that md5 is no longer considered a safe checksum, we recommend you use at least sha256.</para>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry>
+                        <term><option>sha1</option> (string)</term>
+                        <listitem><para>The sha1 checksum of the file, verified after download. This is optional for local files.</para>
+                        <para>Note that sha1 is no longer considered a safe checksum, we recommend you use at least sha256.</para>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry>
                         <term><option>sha256</option> (string)</term>
                         <listitem><para>The sha256 checksum of the file, verified after download. This is optional for local files.</para></listitem>
+                    </varlistentry>
+                    <varlistentry>
+                        <term><option>sha512</option> (string)</term>
+                        <listitem><para>The sha512 checksum of the file, verified after download. This is optional for local files.</para></listitem>
                     </varlistentry>
                     <varlistentry>
                         <term><option>dest-filename</option> (string)</term>

--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -374,8 +374,12 @@
                     <listitem><para>If true, skip this module</para></listitem>
                 </varlistentry>
                 <varlistentry>
-                    <term><option>sources</option> (array of objects)</term>
-                    <listitem><para>An array of objects defining sources that will be downloaded and extracted in order</para></listitem>
+                    <term><option>sources</option> (array of objects or string)</term>
+                    <listitem><para>An array of objects defining
+                    sources that will be downloaded and extracted in
+                    order. String members in the array are interpreted
+                    as the name of a separate json file that contains
+                    sources.  See below for details.</para></listitem>
                 </varlistentry>
                 <varlistentry>
                     <term><option>config-opts</option> (array of strings)</term>
@@ -496,6 +500,11 @@
             <para>
                 These contain a pointer to the source that will be extracted into the source directory before
                 the build starts. They can be of several types, distinguished by the type property.
+            </para>
+            <para>
+                Additionally, the sources list can contain a plain string, which is interpreted as the name
+                of a separate json file that is read and inserted at this point. The json file can contain
+                a single source, or an array of sources.
             </para>
             <refsect3>
                 <title>All sources</title>

--- a/src/builder-context.c
+++ b/src/builder-context.c
@@ -354,7 +354,8 @@ gboolean
 builder_context_download_uri (BuilderContext *self,
                               const char     *url,
                               GFile          *dest,
-                              char           *sha256,
+                              const char     *checksums[BUILDER_CHECKSUMS_LEN],
+                              GChecksumType   checksums_type[BUILDER_CHECKSUMS_LEN],
                               GError        **error)
 {
   int i;
@@ -368,7 +369,7 @@ builder_context_download_uri (BuilderContext *self,
   if (self->sources_urls != NULL)
     {
       g_autofree char *base_name = g_path_get_basename (soup_uri_get_path (original_uri));
-      g_autofree char *rel = g_build_filename ("downloads", sha256, base_name, NULL);
+      g_autofree char *rel = g_build_filename ("downloads", checksums[0], base_name, NULL);
 
       for (i = 0; i < self->sources_urls->len; i++)
         {
@@ -380,7 +381,7 @@ builder_context_download_uri (BuilderContext *self,
 
           if (builder_download_uri (mirror_uri,
                                     dest,
-                                    sha256,
+                                    checksums, checksums_type,
                                     builder_context_get_soup_session (self),
                                     &my_error))
             return TRUE;
@@ -392,7 +393,7 @@ builder_context_download_uri (BuilderContext *self,
 
   if (!builder_download_uri (original_uri,
                              dest,
-                             sha256,
+                             checksums, checksums_type,
                              builder_context_get_soup_session (self),
                              error))
     return FALSE;

--- a/src/builder-context.h
+++ b/src/builder-context.h
@@ -24,6 +24,7 @@
 #include <gio/gio.h>
 #include <libsoup/soup.h>
 #include "builder-options.h"
+#include "builder-utils.h"
 
 G_BEGIN_DECLS
 
@@ -62,7 +63,8 @@ void            builder_context_set_sources_urls (BuilderContext *self,
 gboolean        builder_context_download_uri (BuilderContext *self,
                                               const char     *url,
                                               GFile          *dest,
-                                              char           *sha256,
+                                              const char     *checksums[BUILDER_CHECKSUMS_LEN],
+                                              GChecksumType   checksums_type[BUILDER_CHECKSUMS_LEN],
                                               GError        **error);
 SoupSession *   builder_context_get_soup_session (BuilderContext *self);
 const char *    builder_context_get_arch (BuilderContext *self);

--- a/src/builder-flatpak-utils.c
+++ b/src/builder-flatpak-utils.c
@@ -67,10 +67,13 @@ flatpak_write_update_checksum (GOutputStream  *out,
                                gconstpointer   data,
                                gsize           len,
                                gsize          *out_bytes_written,
-                               GChecksum      *checksum,
+                               GChecksum     **checksums,
+                               gsize           n_checksums,
                                GCancellable   *cancellable,
                                GError        **error)
 {
+  gsize i;
+
   if (out)
     {
       if (!g_output_stream_write_all (out, data, len, out_bytes_written,
@@ -82,8 +85,8 @@ flatpak_write_update_checksum (GOutputStream  *out,
       *out_bytes_written = len;
     }
 
-  if (checksum)
-    g_checksum_update (checksum, data, len);
+  for (i = 0; i < n_checksums; i++)
+    g_checksum_update (checksums[i], data, len);
 
   return TRUE;
 }
@@ -91,7 +94,8 @@ flatpak_write_update_checksum (GOutputStream  *out,
 gboolean
 flatpak_splice_update_checksum (GOutputStream  *out,
                                 GInputStream   *in,
-                                GChecksum      *checksum,
+                                GChecksum     **checksums,
+                                gsize           n_checksums,
                                 FlatpakLoadUriProgress progress,
                                 gpointer        progress_data,
                                 GCancellable   *cancellable,
@@ -108,7 +112,8 @@ flatpak_splice_update_checksum (GOutputStream  *out,
       if (!g_input_stream_read_all (in, buf, sizeof buf, &bytes_read, cancellable, error))
         return FALSE;
 
-      if (!flatpak_write_update_checksum (out, buf, bytes_read, &bytes_written, checksum,
+      if (!flatpak_write_update_checksum (out, buf, bytes_read, &bytes_written,
+                                          checksums, n_checksums,
                                           cancellable, error))
         return FALSE;
 

--- a/src/builder-flatpak-utils.h
+++ b/src/builder-flatpak-utils.h
@@ -276,6 +276,16 @@ flatpak_temp_dir_destroy (void *p)
 typedef GFile FlatpakTempDir;
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakTempDir, flatpak_temp_dir_destroy)
 
+static inline void
+builder_object_list_destroy (void *p)
+{
+  GList *list = p;
+
+  g_list_free_full (list, g_object_unref);
+}
+
+typedef GList BuilderObjectList;
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (BuilderObjectList, builder_object_list_destroy)
 
 #define AUTOLOCK(name) G_GNUC_UNUSED __attribute__((cleanup (flatpak_auto_unlock_helper))) GMutex * G_PASTE (auto_unlock, __LINE__) = flatpak_auto_lock_helper (&G_LOCK_NAME (name))
 

--- a/src/builder-flatpak-utils.h
+++ b/src/builder-flatpak-utils.h
@@ -94,14 +94,16 @@ gboolean flatpak_write_update_checksum (GOutputStream  *out,
                                         gconstpointer   data,
                                         gsize           len,
                                         gsize          *out_bytes_written,
-                                        GChecksum      *checksum,
+                                        GChecksum     **checksums,
+                                        gsize           n_checksums,
                                         GCancellable   *cancellable,
                                         GError        **error);
 
 
 gboolean flatpak_splice_update_checksum (GOutputStream  *out,
                                          GInputStream   *in,
-                                         GChecksum      *checksum,
+                                         GChecksum     **checksums,
+                                         gsize           n_checksums,
                                          FlatpakLoadUriProgress progress,
                                          gpointer        progress_data,
                                          GCancellable   *cancellable,

--- a/src/builder-source-file.c
+++ b/src/builder-source-file.c
@@ -370,9 +370,9 @@ builder_source_file_download (BuilderSource  *source,
       return FALSE;
     }
 
-  if ((self->sha256 == NULL || *self->sha256 == 0) && !is_inline)
+  if (checksums[0] == NULL)
     {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "Sha256 not specified");
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "No checksum specified for file source %s", base_name);
       return FALSE;
     }
 

--- a/src/builder-source-file.c
+++ b/src/builder-source-file.c
@@ -370,7 +370,7 @@ builder_source_file_download (BuilderSource  *source,
       return FALSE;
     }
 
-  if (checksums[0] == NULL)
+  if (checksums[0] == NULL && !is_inline)
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "No checksum specified for file source %s", base_name);
       return FALSE;

--- a/src/builder-source-file.c
+++ b/src/builder-source-file.c
@@ -38,7 +38,10 @@ struct BuilderSourceFile
 
   char         *path;
   char         *url;
+  char         *md5;
+  char         *sha1;
   char         *sha256;
+  char         *sha512;
   char         *dest_filename;
 };
 
@@ -53,7 +56,10 @@ enum {
   PROP_0,
   PROP_PATH,
   PROP_URL,
+  PROP_MD5,
+  PROP_SHA1,
   PROP_SHA256,
+  PROP_SHA512,
   PROP_DEST_FILENAME,
   LAST_PROP
 };
@@ -65,7 +71,10 @@ builder_source_file_finalize (GObject *object)
 
   g_free (self->path);
   g_free (self->url);
+  g_free (self->md5);
+  g_free (self->sha1);
   g_free (self->sha256);
+  g_free (self->sha512);
   g_free (self->dest_filename);
 
   G_OBJECT_CLASS (builder_source_file_parent_class)->finalize (object);
@@ -89,8 +98,20 @@ builder_source_file_get_property (GObject    *object,
       g_value_set_string (value, self->url);
       break;
 
+    case PROP_MD5:
+      g_value_set_string (value, self->md5);
+      break;
+
+    case PROP_SHA1:
+      g_value_set_string (value, self->sha1);
+      break;
+
     case PROP_SHA256:
       g_value_set_string (value, self->sha256);
+      break;
+
+    case PROP_SHA512:
+      g_value_set_string (value, self->sha512);
       break;
 
     case PROP_DEST_FILENAME:
@@ -122,9 +143,24 @@ builder_source_file_set_property (GObject      *object,
       self->url = g_value_dup_string (value);
       break;
 
+    case PROP_MD5:
+      g_free (self->md5);
+      self->md5 = g_value_dup_string (value);
+      break;
+
+    case PROP_SHA1:
+      g_free (self->sha1);
+      self->sha1 = g_value_dup_string (value);
+      break;
+
     case PROP_SHA256:
       g_free (self->sha256);
       self->sha256 = g_value_dup_string (value);
+      break;
+
+    case PROP_SHA512:
+      g_free (self->sha512);
+      self->sha512 = g_value_dup_string (value);
       break;
 
     case PROP_DEST_FILENAME:
@@ -168,6 +204,8 @@ get_download_location (BuilderSourceFile *self,
   const char *path;
   g_autofree char *base_name = NULL;
   g_autoptr(GFile) file = NULL;
+  const char *checksums[BUILDER_CHECKSUMS_LEN];
+  GChecksumType checksums_type[BUILDER_CHECKSUMS_LEN];
 
   uri = get_uri (self, error);
   if (uri == NULL)
@@ -184,22 +222,28 @@ get_download_location (BuilderSourceFile *self,
 
   base_name = g_path_get_basename (path);
 
-  if (self->sha256 == NULL || *self->sha256 == 0)
+  builder_get_all_checksums (checksums, checksums_type,
+                             self->md5,
+                             self->sha1,
+                             self->sha256,
+                             self->sha512);
+
+  if (checksums[0] == NULL)
     {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "Sha256 not specified");
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "No checksum specified for file source %s", base_name);
       return FALSE;
     }
 
   file = builder_context_find_in_sources_dirs (context,
                                                "downloads",
-                                               self->sha256,
+                                               checksums[0],
                                                base_name,
                                                NULL);
   if (file != NULL)
     return g_steal_pointer (&file);
 
   file = flatpak_build_file (builder_context_get_download_dir (context),
-                             self->sha256,
+                             checksums[0],
                              base_name,
                              NULL);
   return g_steal_pointer (&file);
@@ -285,8 +329,9 @@ builder_source_file_download (BuilderSource  *source,
 
   g_autoptr(GFile) file = NULL;
   gboolean is_local, is_inline;
-  g_autofree char *sha256 = NULL;
   g_autofree char *base_name = NULL;
+  const char *checksums[BUILDER_CHECKSUMS_LEN];
+  GChecksumType checksums_type[BUILDER_CHECKSUMS_LEN];
 
   file = get_source_file (self, context, &is_local, &is_inline, error);
   if (file == NULL)
@@ -294,9 +339,15 @@ builder_source_file_download (BuilderSource  *source,
 
   base_name = g_file_get_basename (file);
 
+  builder_get_all_checksums (checksums, checksums_type,
+                             self->md5,
+                             self->sha1,
+                             self->sha256,
+                             self->sha512);
+
   if (g_file_query_exists (file, NULL))
     {
-      if (is_local && self->sha256 != NULL && *self->sha256 != 0)
+      if (is_local && checksums[0] != NULL)
         {
           g_autofree char *data = NULL;
           gsize len;
@@ -304,13 +355,11 @@ builder_source_file_download (BuilderSource  *source,
           if (!g_file_load_contents (file, NULL, &data, &len, NULL, error))
             return FALSE;
 
-          sha256 = g_compute_checksum_for_string (G_CHECKSUM_SHA256, data, len);
-          if (strcmp (sha256, self->sha256) != 0)
-            {
-              g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                           "Wrong sha256 for %s, expected %s, was %s", base_name, self->sha256, sha256);
-              return FALSE;
-            }
+          if (!builder_verify_checksums (base_name,
+                                         data, len,
+                                         checksums, checksums_type,
+                                         error))
+            return FALSE;
         }
       return TRUE;
     }
@@ -330,7 +379,8 @@ builder_source_file_download (BuilderSource  *source,
   if (!builder_context_download_uri (context,
                                      self->url,
                                      file,
-                                     self->sha256,
+                                     checksums,
+                                     checksums_type,
                                      error))
     return FALSE;
 
@@ -422,6 +472,8 @@ builder_source_file_bundle (BuilderSource  *source,
   g_autoptr(GFile) destination_dir = NULL;
   g_autofree char *file_name = NULL;
   gboolean is_local, is_inline;
+  const char *checksums[BUILDER_CHECKSUMS_LEN];
+  GChecksumType checksums_type[BUILDER_CHECKSUMS_LEN];
 
   file = get_source_file (self, context, &is_local, &is_inline, error);
   if (file == NULL)
@@ -430,6 +482,12 @@ builder_source_file_bundle (BuilderSource  *source,
   /* Inline URIs (data://) need not be bundled */
   if (is_inline)
     return TRUE;
+
+  builder_get_all_checksums (checksums, checksums_type,
+                             self->md5,
+                             self->sha1,
+                             self->sha256,
+                             self->sha512);
 
   if (is_local)
     {
@@ -450,7 +508,7 @@ builder_source_file_bundle (BuilderSource  *source,
       file_name = g_file_get_basename (file);
       destination_file = flatpak_build_file (builder_context_get_app_dir (context),
                                              "sources/downloads",
-                                             self->sha256,
+                                             checksums[0],
                                              file_name,
                                              NULL);
     }
@@ -500,6 +558,9 @@ builder_source_file_checksum (BuilderSource  *source,
   builder_cache_checksum_str (cache, self->path);
   builder_cache_checksum_str (cache, self->url);
   builder_cache_checksum_str (cache, self->sha256);
+  builder_cache_checksum_compat_str (cache, self->md5);
+  builder_cache_checksum_compat_str (cache, self->sha1);
+  builder_cache_checksum_compat_str (cache, self->sha512);
   builder_cache_checksum_str (cache, self->dest_filename);
 }
 
@@ -535,8 +596,29 @@ builder_source_file_class_init (BuilderSourceFileClass *klass)
                                                         NULL,
                                                         G_PARAM_READWRITE));
   g_object_class_install_property (object_class,
+                                   PROP_MD5,
+                                   g_param_spec_string ("md5",
+                                                        "",
+                                                        "",
+                                                        NULL,
+                                                        G_PARAM_READWRITE));
+  g_object_class_install_property (object_class,
+                                   PROP_SHA1,
+                                   g_param_spec_string ("sha1",
+                                                        "",
+                                                        "",
+                                                        NULL,
+                                                        G_PARAM_READWRITE));
+  g_object_class_install_property (object_class,
                                    PROP_SHA256,
                                    g_param_spec_string ("sha256",
+                                                        "",
+                                                        "",
+                                                        NULL,
+                                                        G_PARAM_READWRITE));
+  g_object_class_install_property (object_class,
+                                   PROP_SHA512,
+                                   g_param_spec_string ("sha512",
                                                         "",
                                                         "",
                                                         NULL,

--- a/src/builder-utils.h
+++ b/src/builder-utils.h
@@ -29,6 +29,9 @@
 
 G_BEGIN_DECLS
 
+#define BUILDER_N_CHECKSUMS 4 /* We currently support 4 checksum types */
+#define BUILDER_CHECKSUMS_LEN (BUILDER_N_CHECKSUMS + 1) /* One more for null termination */
+
 typedef struct BuilderUtils BuilderUtils;
 
 char *builder_uri_to_filename (const char *uri);
@@ -69,9 +72,24 @@ gboolean builder_maybe_host_spawnv (GFile                *dir,
 
 gboolean builder_download_uri (SoupURI        *uri,
                                GFile          *dest,
-                               char           *sha256,
+                               const char     *checksums[BUILDER_CHECKSUMS_LEN],
+                               GChecksumType   checksums_type[BUILDER_CHECKSUMS_LEN],
                                SoupSession    *soup_session,
                                GError        **error);
+
+gsize builder_get_all_checksums (const char *checksums[BUILDER_CHECKSUMS_LEN],
+                                 GChecksumType checksums_type[BUILDER_CHECKSUMS_LEN],
+                                 const char *md5,
+                                 const char *sha1,
+                                 const char *sha256,
+                                 const char *sha512);
+
+gboolean builder_verify_checksums (const char *name,
+                                   const char *data,
+                                   gsize len,
+                                   const char *checksums[BUILDER_CHECKSUMS_LEN],
+                                   GChecksumType checksums_type[BUILDER_CHECKSUMS_LEN],
+                                   GError **error);
 
 GParamSpec * builder_serializable_find_property_with_error (JsonSerializable *serializable,
                                                             const char       *name);


### PR DESCRIPTION
The latest flatpak-builder pulls a new ostree and flatpak, which is tracked in T21140 - in the meantime these 5 commits should allow us to build the syntax that NPM generator requires.

https://phabricator.endlessm.com/T21415