### PR TITLE
manifest: Add support for "extension-tag"

### DIFF
--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -77,7 +77,7 @@
                     locations for the same extension point with the intention that
                     different branches for the extension are mounted at each location. When
                     building an extension it is necessary to know what extension point to
-                    install the extension to. This option resolves the any ambiguity
+                    install the extension to. This option resolves any ambiguity
                     in which extension point to choose. If not specified, the default choice
                     is to install into either the only location for the extension point or
                     into the location for the untagged extension point. If there are multiple

--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -82,7 +82,7 @@
                     is to install into either the only location for the extension point or
                     into the location for the untagged extension point. If there are multiple
                     locations for the same extension point defined with different tags
-                    then an error will occurr.</para></listitem>
+                    then an error will occur.</para></listitem>
                 </varlistentry>
                 <varlistentry>
                     <term><option>runtime</option> (string)</term>

--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -71,6 +71,20 @@
                     repository.</para></listitem>
                 </varlistentry>
                 <varlistentry>
+                    <term><option>extension-tag</option> (string)</term>
+                    <listitem><para>If building an extension, the tag for the extension
+                    point to use. Since flatpak 0.11.4 a runtime may define multiple
+                    locations for the same extension point with the intention that
+                    different branches for the extension are mounted at each location. When
+                    building an extension it is necessary to know what extension point to
+                    install the extension to. This option resolves the any ambiguity
+                    in which extension point to choose. If not specified, the default choice
+                    is to install into either the only location for the extension point or
+                    into the location for the untagged extension point. If there are multiple
+                    locations for the same extension point defined with different tags
+                    then an error will occurr.</para></listitem>
+                </varlistentry>
+                <varlistentry>
                     <term><option>runtime</option> (string)</term>
                     <listitem><para>The name of the runtime that the application uses.</para></listitem>
                 </varlistentry>

--- a/src/builder-manifest.c
+++ b/src/builder-manifest.c
@@ -62,6 +62,7 @@ struct BuilderManifest
   char           *id_platform;
   char           *branch;
   char           *collection_id;
+  char           *extension_tag;
   char           *type;
   char           *runtime;
   char           *runtime_commit;
@@ -159,6 +160,7 @@ enum {
   PROP_DESKTOP_FILE_NAME_SUFFIX,
   PROP_COLLECTION_ID,
   PROP_ADD_EXTENSIONS,
+  PROP_EXTENSION_TAG,
   LAST_PROP
 };
 
@@ -170,6 +172,7 @@ builder_manifest_finalize (GObject *object)
   g_free (self->id);
   g_free (self->branch);
   g_free (self->collection_id);
+  g_free (self->extension_tag);
   g_free (self->runtime);
   g_free (self->runtime_commit);
   g_free (self->runtime_version);
@@ -431,6 +434,10 @@ builder_manifest_get_property (GObject    *object,
       g_value_set_string (value, self->collection_id);
       break;
 
+    case PROP_EXTENSION_TAG:
+      g_value_set_string (value, self->extension_tag);
+      break;
+
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
@@ -666,6 +673,11 @@ builder_manifest_set_property (GObject      *object,
     case PROP_COLLECTION_ID:
       g_free (self->collection_id);
       self->collection_id = g_value_dup_string (value);
+      break;
+
+    case PROP_EXTENSION_TAG:
+      g_free (self->extension_tag);
+      self->extension_tag = g_value_dup_string (value);
       break;
 
     default:
@@ -977,6 +989,14 @@ builder_manifest_class_init (BuilderManifestClass *klass)
   g_object_class_install_property (object_class,
                                    PROP_COLLECTION_ID,
                                    g_param_spec_string ("collection-id",
+                                                        "",
+                                                        "",
+                                                        NULL,
+                                                        G_PARAM_READWRITE));
+
+  g_object_class_install_property (object_class,
+                                   PROP_EXTENSION_TAG,
+                                   g_param_spec_string ("extension-tag",
                                                         "",
                                                         "",
                                                         NULL,
@@ -1302,6 +1322,12 @@ builder_manifest_set_default_collection_id (BuilderManifest *self,
     self->collection_id = g_strdup (default_collection_id);
 }
 
+const char *
+builder_manifest_get_extension_tag (BuilderManifest *self)
+{
+  return self->extension_tag;
+}
+
 static const char *
 builder_manifest_get_base_version (BuilderManifest *self)
 {
@@ -1501,6 +1527,9 @@ builder_manifest_init_app_dir (BuilderManifest *self,
         }
     }
 
+  if (self->extension_tag != NULL)
+    g_ptr_array_add (args, g_strdup_printf ("--extension-tag=%s", self->extension_tag));
+
   g_ptr_array_add (args, g_strdup_printf ("--arch=%s", builder_context_get_arch (context)));
   g_ptr_array_add (args, g_file_get_path (app_dir));
   g_ptr_array_add (args, g_strdup (self->id));
@@ -1567,6 +1596,7 @@ builder_manifest_checksum (BuilderManifest *self,
   builder_cache_checksum_str (cache, self->base_version);
   builder_cache_checksum_str (cache, self->base_commit);
   builder_cache_checksum_strv (cache, self->base_extensions);
+  builder_cache_checksum_compat_str (cache, self->extension_tag);
 
   if (self->build_options)
     builder_options_checksum (self->build_options, cache, context);
@@ -2447,6 +2477,15 @@ builder_manifest_cleanup (BuilderManifest *self,
   return TRUE;
 }
 
+static char *
+maybe_format_extension_tag (const char *extension_tag)
+{
+  if (extension_tag != NULL)
+    return g_strdup_printf ("tag=%s\n", extension_tag);
+
+  return g_strdup ("");
+}
+
 
 gboolean
 builder_manifest_finish (BuilderManifest *self,
@@ -2793,18 +2832,23 @@ builder_manifest_finish (BuilderManifest *self,
           g_autofree char *extension_metadata_name = NULL;
           g_autoptr(GFile) metadata_extension_file = NULL;
           g_autofree char *metadata_contents = NULL;
+          g_autofree char *extension_tag_opt = NULL;
 
           if (!builder_extension_is_bundled (e))
             continue;
 
+          extension_tag_opt = maybe_format_extension_tag (builder_manifest_get_extension_tag (self));
           extension_metadata_name = g_strdup_printf ("metadata.%s", builder_extension_get_name (e));
           metadata_extension_file = g_file_get_child (app_dir, extension_metadata_name);
           metadata_contents = g_strdup_printf ("[Runtime]\n"
                                                "name=%s\n"
                                                "\n"
                                                "[ExtensionOf]\n"
-                                               "ref=%s\n",
-                                               builder_extension_get_name (e), ref);
+                                               "ref=%s\n"
+                                               "%s",
+                                               builder_extension_get_name (e),
+                                               ref,
+                                               extension_tag_opt);
           if (!g_file_set_contents (flatpak_file_get_path_cached (metadata_extension_file),
                                     metadata_contents, strlen (metadata_contents), error))
             return FALSE;

--- a/src/builder-manifest.h
+++ b/src/builder-manifest.h
@@ -62,6 +62,7 @@ const char *    builder_manifest_get_branch (BuilderManifest *self);
 void            builder_manifest_set_default_branch (BuilderManifest *self,
                                                      const char *default_branch);
 const char *    builder_manifest_get_collection_id (BuilderManifest *self);
+const char *    builder_manifest_get_extension_tag (BuilderManifest *self);
 void            builder_manifest_set_default_collection_id (BuilderManifest *self,
                                                             const char      *default_collection_id);
 


### PR DESCRIPTION
This passes an --extension-tag to flatpak build-init which will
set the "tag" option on the ExtensionOf section in the metadata.

Closes: #126
Approved by: alexlarsson

https://phabricator.endlessm.com/T22077